### PR TITLE
Add a reminder of use mappings for css

### DIFF
--- a/src/pages/learn/css/inline-styles.mdx
+++ b/src/pages/learn/css/inline-styles.mdx
@@ -46,9 +46,7 @@ let element: HTMLElement = <div style={{ color: use(state.color) }}>Hello, world
 ```
 </Code>
 
-This is the ideal solution for when styles change often, but is not optimal for more static css.
-
-If you want css values with more complex outputs you have to tie in a callback to compute the value when the state changes.
+If you want your css values to update with more complex outputs you can tie in a callback to compute the value when the state changes:
 
 <Code>
 ```js
@@ -75,3 +73,5 @@ let state: {
 let element: HTMLElement = <div style={{ top: use(state.line, (line) => `${line}em` }}>Hello, world!</div>;
 ```
 </Code>
+
+This is the ideal solution for when styles change often, but is not optimal for more static css.

--- a/src/pages/learn/css/inline-styles.mdx
+++ b/src/pages/learn/css/inline-styles.mdx
@@ -46,7 +46,7 @@ let element: HTMLElement = <div style={{ color: use(state.color) }}>Hello, world
 ```
 </Code>
 
-If you want your css values to update with more complex outputs you can tie in a callback to compute the value when the state changes:
+If you want your css values to have more complex values use reactive strings:
 
 <Code>
 ```js
@@ -54,14 +54,14 @@ let state = $state({
 	line: 0,
 });
 
-let element = html`<div style=${{ line: use(state.line, (line) => `${line}em` }}>Hello, world!</div>`;
+let element = html`<div style=${{ line: use`${state.line}em` }}>Hello, world!</div>`;
 ```
 ```jsx
 let state = $state({
 	line: 10,
 });
 
-let element = <div style={{ top: use(state.line, (line) => `${line}em`) }}>Hello, world!</div>;
+let element = <div style={{ top: use`${state.line}em` }}>Hello, world!</div>;
 ```
 ```tsx
 let state: {
@@ -70,7 +70,7 @@ let state: {
 	line: 10,
 });
 
-let element: HTMLElement = <div style={{ top: use(state.line, (line) => `${line}em` }}>Hello, world!</div>;
+let element: HTMLElement = <div style={{ top: use`${state.line}em` }}>Hello, world!</div>;
 ```
 </Code>
 

--- a/src/pages/learn/css/inline-styles.mdx
+++ b/src/pages/learn/css/inline-styles.mdx
@@ -46,4 +46,32 @@ let element: HTMLElement = <div style={{ color: use(state.color) }}>Hello, world
 ```
 </Code>
 
-This is the ideal solution for when styles change often, but is not optimal for more static css
+This is the ideal solution for when styles change often, but is not optimal for more static css.
+
+If you want css values with more complex outputs you have to tie in a callback to compute the value when the state changes.
+
+<Code>
+```js
+let state = $state({
+	line: 0,
+});
+
+let element = html`<div style=${{ line: use(state.line, (line) => `${line}em` }}>Hello, world!</div>`;
+```
+```jsx
+let state = $state({
+	line: 10,
+});
+
+let element = <div style={{ top: use(state.line, (line) => `${line}em`) }}>Hello, world!</div>;
+```
+```tsx
+let state: {
+	line: number 
+} = $state({
+	line: 10,
+});
+
+let element: HTMLElement = <div style={{ top: use(state.line, (line) => `${line}em` }}>Hello, world!</div>;
+```
+</Code>


### PR DESCRIPTION
Missed the custom `use` output mapping on my first skim through of the docs, would be useful to have a reminder in a situation where mappings would actually be applicable.